### PR TITLE
Added a fix for people.html not loading styles.css, etc.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -83,7 +83,7 @@ body {
   height: 100%;
 }
 
-#racingDuck{
+#racingDuck {
   margin-left: 0%;
   width: fit-content;
 }

--- a/duck_devs_info.json
+++ b/duck_devs_info.json
@@ -1,8 +1,28 @@
 [
   {
+    "name": "Chris Minnick",
+    "role": "C$",
+    "githubLink": "https://github.com/chrisminnick"
+  },
+  {
+    "name": "Chris Penick",
+    "role": "DJ Crispy",
+    "githubLink": "https://github.com/chrispenick"
+  },
+  {
     "name": "Dan Savidge",
     "role": "Software Engineer",
     "githubLink": "https://github.com/dsavidge02"
+  },
+  {
+    "name": "Arvind Kasiliya",
+    "role": "Software Engineer",
+    "githubLink": "https://github.com/Arvonit"
+  },
+  {
+    "name": "Dustin Hagstrom",
+    "role": "Software Engineer",
+    "githubLink": "https://github.com/dustinhagstrom"
   },
   {
     "name": "Will Sibble",

--- a/people.html
+++ b/people.html
@@ -1,9 +1,9 @@
 <html>
   <head>
     <title>Duck Devs</title>
-    <link rel="stylesheet" type="text/css" href="/css/style.css" />
-    <link rel="stylesheet" type="text/css" href="/css/people.css" />
-    <script defer src="/js/people.js"></script>
+    <link rel="stylesheet" type="text/css" href="css/style.css" />
+    <link rel="stylesheet" type="text/css" href="css/people.css" />
+    <script defer src="js/people.js"></script>
   </head>
   <body>
     <nav class="navbar">


### PR DESCRIPTION
Noticed a weird functionality with github pages where "/js/people.js" is a link to chrisminnick.github.io/js/people.js instead of the desired /duckdevs/js/people.js - I'm pretty sure removing the beginning "/" should fix this